### PR TITLE
Delete existing input manifests in generate

### DIFF
--- a/input/generate.go
+++ b/input/generate.go
@@ -4,6 +4,8 @@
 // NOTE(negz): See the below link for details on what is happening here.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
+// Remove existing and generate new input manifests
+//go:generate rm -rf ../package/input/
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen paths=./v1beta1 object crd:crdVersions=v1 output:artifacts:config=../package/input
 
 package input


### PR DESCRIPTION
### Description of your changes

Remove any existing `Input` manifests during generate. Without deletion the default template Input CRD will be in the package and installed with the Function. This can cause Ownership issues on the XP Cluster where multiple functions are installed. 


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
