### PR TITLE
Update apiVersion for function manifest

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-template-go


### PR DESCRIPTION

### Description of your changes
Updates the `apiVersion` to match latest master install.

I installed the latest master Crossplane and tried to apply the function in `package/crossplane.yaml` but it failed with:
```
error: resource mapping not found for name: "test-function" namespace: "" from "package/crossplane.yaml": no matches for kind "Function" in version "meta.pkg.crossplane.io/v1beta1"
ensure CRDs are installed first
```

The fix is to use `pkg.crossplane.io/v1beta1` instead of `meta.pkg.crossplane.io/v1beta1`. `pkg.crossplane.io/v1beta1` also matches what is mentioned in the `README.md`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
