### PR TITLE
Use Go style pseudo-versions when there is no semver supplied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,10 +152,12 @@ jobs:
           password: ${{ secrets.XPKG_TOKEN }}
 
       # If a version wasn't explicitly passed as a workflow_dispatch input we
-      # default to version v0.0.0-shortsha, for example v0.0.0-8ed5691.
+      # default to version v0.0.0-<git-commit-date>-<git-short-sha>, for example
+      # v0.0.0-20231101115142-1091066df799. This is a simple implementation of
+      # Go's pseudo-versions: https://go.dev/ref/mod#pseudo-versions.
       - name: Set Default Multi-Platform Package Version
         if: env.XPKG_VERSION == ''
-        run: echo "XPKG_VERSION=v0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "XPKG_VERSION=v0.0.0-$(date -d@$(git show -s --format=%ct) +%Y%m%d%H%M%S)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
 
       - name: Push Multi-Platform Package to Upbound
         if: env.XPKG_ACCESS_ID != ''


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The CI workflow uses a semver (e.g. v1.0.0) when you run it using the workflow_dispatch trigger and supply one explicitly. This is how you 'release' a function.

Today when the workflow runs for a PR or regular main branch build we default to `v0.0.0-<git-short-sha>` (e.g. `v0.0.0-9be3d00`). This is a very simple way to tag development builds with no user input required. It's handy that the resulting package can be correlated to the git commit that produced it using the git SHA.

A major flaw of this implementation is that newer SHAs do not sort above older SHAs when treated as semantic versions.

This commit switches us to a simple approximation of the Go pseudoversions you would see in a go.mod file, as described by https://go.dev/ref/mod#pseudo-versions. These versions include the git commit time before the SHA, so newer commits will be considered newer versions when processing the semver. We also switch to using the first 12 characters of the SHA. This reduces the risk of collision, and makes us match exactly Go's pseudoversion implementation.

Development packages will now be pushed with a tag like `v0.0.0-20231101115142-1091066df799`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
