### PR TITLE
Enhance init.sh update Go module paths as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you just want to jump in and get started:
 
 1. Replace `function-template-go` with your function in `go.mod`,
    `package/crossplane.yaml`, and any Go imports. (You can also do this
-   automatically by running the `./init.sh <function-name>` script.)
+   automatically by running the `./init.sh <Go module: github.com/my-org/my-fn-name>` script.)
 1. Update `input/v1beta1/` to reflect your desired input (and run `go generate`)
 1. Add your logic to `RunFunction` in `fn.go`
 1. Add tests for your logic in `fn_test.go`

--- a/init.sh
+++ b/init.sh
@@ -3,19 +3,25 @@
 # This script helps initialize a new function project by
 # replacing all instances of function-template-go with the
 # name of your function. The scripts accepts two arguments:
-# 1. The name of your function
+# 1. The go module of your function, example: github.com/my-org/my-function
 # 2. The path to your function directory
 
 set -e
 
-cd "$2" || return
+# Arguments
+module_path="$1"
+project_dir="$2"
+# Extract the last element of the module path using `basename`
+function_name=$(basename "${module_path}")
 
-# Replace function-template-go with the name of your function
+cd "$project_dir" || return
+
+# Replaces function-template-go with the name of your function
 # in go.mod
-perl -pi -e s,function-template-go,"$1",g go.mod
+perl -pi -e s,github.com/crossplane/function-template-go,"${module_path}",g go.mod
 # in fn.go
-perl -pi -e s,function-template-go,"$1",g fn.go
+perl -pi -e s,github.com/crossplane/function-template-go,"${module_path}",g fn.go
 # in examples
-perl -pi -e s,function-template-go,"$1",g example/*
+perl -pi -e s,function-template-go,"${function_name}",g example/*
 
-echo "Function $1 has been initialised successfully"
+echo "Function ${function_name} has been initialised successfully"


### PR DESCRIPTION
### Description of your changes
Enhance `./init.sh` to accept a Go module path as first input and correctly replace it in all go files.
From the path, the last segment gets extracted and used as function/package name.


Fixes #74 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
