### PR TITLE
Add check for go mod tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false  # The golangci-lint action does its own caching.
 
+      - name: Check go mod tidy
+        run: go mod tidy && git diff --exit-code go.mod go.sum
+
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -70,7 +73,7 @@ jobs:
   # We want to build most packages for the amd64 and arm64 architectures. To
   # speed this up we build single-platform packages in parallel. We then upload
   # those packages to GitHub as a build artifact. The push job downloads those
-  # artifacts and pushes them as a single multi-platform package. 
+  # artifacts and pushes them as a single multi-platform package.
   build:
     runs-on: ubuntu-24.04
     strategy:
@@ -108,13 +111,13 @@ jobs:
           build-args:
             GO_VERSION=${{ env.GO_VERSION }}
           outputs: type=docker,dest=runtime-${{ matrix.arch }}.tar
-      
+
       - name: Setup the Crossplane CLI
         run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
 
       - name: Build Package
         run: ./crossplane xpkg build --package-file=${{ matrix.arch }}.xpkg --package-root=package/ --embed-runtime-image-tarball=runtime-${{ matrix.arch }}.tar
-      
+
       - name: Upload Single-Platform Package
         uses: actions/upload-artifact@v4
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,9 @@
       "matchFileNames": ["example/**"],
       "groupName": "examples"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
### Description of your changes

ref: https://github.com/crossplane-contrib/function-go-templating/pull/105#issuecomment-2258999671

1. It looks like the go.sum is very bloated due to missing cleanup. All I have done is run `go mod tidy` to remove unused dependencies. This is generally a good practice and results in faster downloads/less cache.
2. Also added config to renovate to instruct it to do the `go mod tidy` whenever it upgrades a dependency.
3. Add a check in lint to catch future missing cleanup

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `go test ./...`
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute