### PR TITLE
feature(grpc): allow the configuration of GRPC default MaxRecvMessageSize

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ type CLI struct {
 	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
 	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
 	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize  int    `help:"Maximum size of received messages in MB." default:"4"`
+
 }
 
 // Run this Function.
@@ -27,7 +29,8 @@ func (c *CLI) Run() error {
 	return function.Serve(&Function{log: log},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
-		function.Insecure(c.Insecure))
+		function.Insecure(c.Insecure),
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize * 1024 * 1024))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -11,12 +11,11 @@ import (
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
 
-	Network     string `help:"Network on which to listen for gRPC connections." default:"tcp"`
-	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
-	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
-	MaxRecvMessageSize  int    `help:"Maximum size of received messages in MB." default:"4"`
-
+	Network            string `help:"Network on which to listen for gRPC connections." default:"tcp"`
+	Address            string `help:"Address at which to listen for gRPC connections." default:":9443"`
+	TLSCertsDir        string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
+	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize int    `help:"Maximum size of received messages in MB." default:"4"`
 }
 
 // Run this Function.
@@ -30,7 +29,7 @@ func (c *CLI) Run() error {
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure),
-		function.MaxRecvMessageSize(c.MaxRecvMessageSize * 1024 * 1024))
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
 }
 
 func main() {


### PR DESCRIPTION
Allows the configuration of the default value of `MaxRecvMessageSize`. 

Default value is set to 4MB to follow [underlying existing work](https://github.com/grpc/grpc-go/blob/0775031253f395d1008f80da5f0582b8871f143e/server.go#L57C2-L57C36).

Fixes # 

https://github.com/crossplane-contrib/function-auto-ready/issues/40
https://github.com/crossplane/function-sdk-go/issues/194

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~[ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
