### PR TITLE
Fixes for `xpkg init` generation recommendations and CI workflow for uppercase github org names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,4 +164,6 @@ jobs:
 
       - name: Push Multi-Platform Package to Upbound
         if: env.XPKG_ACCESS_ID != ''
-        run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${{ env.XPKG }}:${{ env.XPKG_VERSION }}"
+        # XPKG repo name can't contain uppercase characters like UpboundCare, we need to lowercase if the GithubOrg contains them.
+        # See https://github.com/orgs/community/discussions/25768#discussioncomment-8057564 for XPKG@L lowercase explanation
+        run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${XPKG@L}:${{ env.XPKG_VERSION }}"

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -3,7 +3,7 @@ To get started:
 1. Replace `function-template-go` with your function in `go.mod`,
    `package/crossplane.yaml`, and any Go imports. (You can also do this
    automatically by running the `./init.sh <function-name>` script.)
-2. Update `input/v1beta1/` to reflect your desired input (and run `go generate`)
+2. Update `input/v1beta1/` to reflect your desired input (and run `go generate ./...`)
 3. Add your logic to `RunFunction` in `fn.go`
 4. Add tests for your logic in `fn_test.go`
 5. Update `README.md`, to be about your function!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you just want to jump in and get started:
 1. Replace `function-template-go` with your function in `go.mod`,
    `package/crossplane.yaml`, and any Go imports. (You can also do this
    automatically by running the `./init.sh <function-name>` script.)
-1. Update `input/v1beta1/` to reflect your desired input (and run `go generate`)
+1. Update `input/v1beta1/` to reflect your desired input (and run `go generate ./...`)
 1. Add your logic to `RunFunction` in `fn.go`
 1. Add tests for your logic in `fn_test.go`
 1. Update this file, `README.md`, to be about your function!


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* `go generate` -> `go generate ./...` in NOTES and readme. It is visible right after `crossplane xpkg init` so it is important to provide correct CLI instructions to the user

* Avoid failure in CI workflow by handling cases for GitHub organizations with uppercase characters in their names, e.g. `UpboundCare`. Before this change you would hit the failure similar to the one below
```
crossplane: error: failed to parse package tag "xpkg.upbound.io/UpboundCare/function-azresourcegraph:v0.0.0-20241211161841-62aad247be2c": repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: UpboundCare/function-azresourcegraph
```


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
