### PR TITLE
Update golangci-lint configuration to work with latest linter versions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,10 @@
 run:
   timeout: 10m
 
-  skip-files:
-  - "zz_generated\\..+\\.go$"
-
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -18,14 +16,15 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    # List of functions to exclude from checking, where each entry is a single function to exclude.
+    # See https://github.com/kisielk/errcheck#excluding-functions for details.
+    exclude-functions:
+      - io/ioutil.ReadFile
 
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    disable:
+      - shadow
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -44,10 +43,6 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
 
   dupl:
     # tokens count to trigger issue, 150 by default
@@ -116,7 +111,7 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-  
+
   disable:
     # These linters are all deprecated as of golangci-lint v1.49.0. We disable
     # them explicitly to avoid the linter logging deprecation warnings.
@@ -135,6 +130,9 @@ linters:
 issues:
   # Excluding configuration per-path and per-linter
   exclude-rules:
+    - path: "zz_generated\\..+\\.go$"
+      linters: ["all"]
+
     # Exclude some linters from running on tests files.
     - path: _test(ing)?\.go
       linters:
@@ -181,7 +179,7 @@ issues:
       linters:
       - gosec
       - gas
-    
+
     # Some k8s dependencies do not have JSON tags on all fields in structs.
     - path: k8s.io/
       linters:
@@ -202,7 +200,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Follow `golangci-lint config verify` errors and fix them according to the latest https://golangci-lint.run/usage/configuration/ and https://golangci-lint.run/usage/linters

* It should proactively fix the associated pipeline failures

Before:
```
golangci-lint config verify
jsonschema: "run" does not validate with "/properties/run/additionalProperties": additionalProperties 'skip-files' not allowed
jsonschema: "output" does not validate with "/properties/output/additionalProperties": additionalProperties 'format' not allowed
jsonschema: "linters-settings.govet" does not validate with "/properties/linters-settings/properties/govet/additionalProperties": additionalProperties 'check-shadowing' not allowed
jsonschema: "linters-settings.errcheck" does not validate with "/properties/linters-settings/properties/errcheck/additionalProperties": additionalProperties 'ignore' not allowed
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additionalProperties 'maligned' not allowed
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additionalProperties 'max-per-linter' not allowed
Failed executing command with error: the configuration contains invalid elements
```

After:
```
golangci-lint config verify
echo $?
0
```

Originally updated in the context of https://github.com/upbound/function-azresourcegraph/pull/43

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
